### PR TITLE
add error handing for cases where user leaves before timeout ends

### DIFF
--- a/src/index.cjs
+++ b/src/index.cjs
@@ -333,6 +333,7 @@ class Captcha extends EventEmitter {
                         await captchaEmbed.delete({
                             reason: "Captcha Timeout"
                         });
+                        try{
                         await channel.send({
                             embeds: [captchaIncorrect],
                         }).then(async msg => {
@@ -366,6 +367,9 @@ class Captcha extends EventEmitter {
                                 }
                             }
                         })
+                    } catch (e){
+                        console.log((captchaData.options.kickIfRoleRemoved && captchaData.options.kickIfRoleAdded) ? "Either user has left server or kick user failed" : "User has left the server.");
+                    }
                         return false;
                     }
 
@@ -484,6 +488,7 @@ class Captcha extends EventEmitter {
                         }
 
                         // If channel is in a DM, it will send the incorrect embed.
+                        try{
                         await channel.send({
                             embeds: [captchaIncorrect],
                         }).then(async msg => {
@@ -501,7 +506,11 @@ class Captcha extends EventEmitter {
                                 }
                             }
 
-                        })
+                        });
+                    } catch(e){
+                console.log((captchaData.options.kickIfRoleRemoved && captchaData.options.kickIfRoleAdded) ? "[CAPTCHA] Either user"+ member.user.username +" has left server or kick user failed" : "[CAPTCHA] User" + member.user.username +" has left the server.");
+                    }
+
                         return false;
 
                     }


### PR DESCRIPTION
# Description

Added some error handling for an edge case that appeared in my discord bot.
<br/>
<br/>

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Steps to replicate bug:
Present captcha
once captcha is presented in DM, leave server
after timeout is reached, the bot tries to send the captcha fail message, but it fails because user is not in the server anymore, which throws an API exception.

Solution: Adding a try{} catch{} block in the message.send method which will tell whether the user has left the server or whether kicking the user has failed